### PR TITLE
src/main.cpp: Enable High DPI scaling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,8 @@
 * @author Gassan Idriss <ghassani@gmail.com>
 */
 
+#include <QGuiApplication>
+
 #include "application.h"
 #include "sahara_window.h"
 
@@ -35,6 +37,7 @@
  */
 int main(int argc, char *argv[])
 {
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     OpenPST::GUI::Application application(argc, argv, "sahara_");
 
     OpenPST::GUI::SaharaWindow window;


### PR DESCRIPTION
Qt 5.6 adds a feature to enable high DPI scaling which makes the
UI legible on these types of screen.